### PR TITLE
Remove unnecessary libraries in 4_citationcount_from_local_db.py

### DIFF
--- a/extraction_citations_V2_dataset/4_citationcount_from_local_db.py
+++ b/extraction_citations_V2_dataset/4_citationcount_from_local_db.py
@@ -1,7 +1,5 @@
 import sqlite3
 import csv
-from urllib3.util.retry import Retry
-from requests.adapters import HTTPAdapter
 
 #### Takes previously produced metadata+citations database and creates a CSV file
 #### that has articles grouped by DOI, year and citation count.


### PR DESCRIPTION
Requests and urllib libraries are not used in this file.